### PR TITLE
fix: update NixOS wiki link

### DIFF
--- a/answers/concepts.md
+++ b/answers/concepts.md
@@ -37,7 +37,7 @@ Nix 语言是一门函数式编程语言, 它的核心数据结构类似JSON, �
 - 采用惰性求值策略
 - 具体语法有些模仿命令式语言的赋值语句 (如可以写 `{ a.b.c = 1; }`, 它等价于 `{ a = { b = { c = 1; }; }; }`, 并且多个这样的 "赋值语句" 还能合并 ) , 但内核实际上是声明式的
 
-大概就是这样子, 熟悉 Haskell 或 Lisp 系列的玩家只需要话几分钟去看看关于具体语法的 [官方文档](https://nixos.wiki/wiki/Nix_Expression_Language) 以及一些 [文章](https://nixery.dev/nix-1p.html) 即可, 这里不赘述。
+大概就是这样子, 熟悉 Haskell 或 Lisp 系列的玩家只需要话几分钟去看看关于具体语法的 [官方文档](https://wiki.nixos.org/wiki/Nix_Expression_Language) 以及一些 [文章](https://nixery.dev/nix-1p.html) 即可, 这里不赘述。
 
 
 作为包管理器的 Nix

--- a/answers/how-to-upgrade-nixos-version.md
+++ b/answers/how-to-upgrade-nixos-version.md
@@ -48,7 +48,7 @@ nixos https://nixos.org/channels/nixos-20.09
 ```sh
 sudo nix-channel --update
 ```
-这一步类似的作用是更新本机channel中的nix表达式，类似 `sudo apt-get update` , 参考 [Wiki](https://nixos.wiki/wiki/Cheatsheet)。
+这一步类似的作用是更新本机channel中的nix表达式，类似 `sudo apt-get update` , 参考 [Wiki](https://wiki.nixos.org/wiki/Cheatsheet)。
 
 更多说明：[channel 所有者](#channel-所有者)
 

--- a/answers/what-is-nix-flakes.md
+++ b/answers/what-is-nix-flakes.md
@@ -6,4 +6,4 @@
 
 其中第一篇和第三篇解释了 flakes 的设计动机，或者说 nix 项目目前遇到的一些问题。
 
-另外，[官方wiki](https://nixos.wiki/wiki/Flakes) 也可以作为补充阅读
+另外，[官方wiki](https://wiki.nixos.org/wiki/Flakes) 也可以作为补充阅读

--- a/answers/what-is-nixos-module.md
+++ b/answers/what-is-nixos-module.md
@@ -1,1 +1,1 @@
-见官方wiki： https://nixos.wiki/wiki/Module
+见官方wiki： https://wiki.nixos.org/wiki/Module

--- a/answers/what-is-nixpkgs-overlays.md
+++ b/answers/what-is-nixpkgs-overlays.md
@@ -1,1 +1,1 @@
-见官方wiki： https://nixos.wiki/wiki/Overlays
+见官方wiki： https://wiki.nixos.org/wiki/Overlays


### PR DESCRIPTION
你好!

This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113